### PR TITLE
index.ejs line 12 correction

### DIFF
--- a/Chapter_03/guestbook/views/index.ejs
+++ b/Chapter_03/guestbook/views/index.ejs
@@ -9,7 +9,7 @@
         <%= entry.title %>
       </div>
       <div class="panel-body">
-        <%= entry.body %>
+        <%= entry.content %>
       </div>
     </div>
   <% }) %>


### PR DESCRIPTION
The object in app.js has title, content, and published  as properties. When running the server, the content didn't render because in index.ejs, line 12 had <%= entry.body %> it should be <%= entry.content %>