### PR TITLE
Update temper-zip to use darksky.net

### DIFF
--- a/Chapter_05/temperature-by-zip-code/app.js
+++ b/Chapter_05/temperature-by-zip-code/app.js
@@ -1,10 +1,16 @@
 var path = require("path");
 var express = require("express");
 var zipdb = require("zippity-do-dah");
-var ForecastIo = require("forecastio");
+var DarkSky = require('forecast.io');
+//https://www.npmjs.com/package/forecast.io
 
 var app = express();
-var weather = new ForecastIo("YOUR FORECAST.IO API KEY HERE");
+
+var options = {
+  APIKey: "pasteYourDarksky.netSecretApiKeyHere",
+  timeout: 1000
+},
+darksky = new DarkSky(options);
 
 app.use(express.static(path.resolve(__dirname, "public")));
 
@@ -25,13 +31,9 @@ app.get(/^\/(\d{5})$/, function(req, res, next) {
 
   var latitude = location.latitude;
   var longitude = location.longitude;
-
-  weather.forecast(latitude, longitude, function(err, data) {
-    if (err) {
-      next();
-      return;
-    }
-
+  
+  darksky.get(latitude, longitude, function (err, result, data) {
+    if (err) throw err;
     res.json({
       zipcode: zipcode,
       temperature: data.currently.temperature

--- a/Chapter_05/temperature-by-zip-code/package.json
+++ b/Chapter_05/temperature-by-zip-code/package.json
@@ -7,7 +7,7 @@
   "dependencies": {
     "ejs": "^2.3.1",
     "express": "5.0.0-alpha.2",
-    "forecastio": "^0.2.0",
+    "forecast.io": "0.0.11",
     "zippity-do-dah": "0.0.x"
   }
 }


### PR DESCRIPTION
I'm unable to repro the original problems I had with the original code.  Maybe should reject this PR.  Now I have a key (darksky, not forecast.io, unlike the book), and that darksky api key seems to work with the original code from the book&repo.  

Could change 
var weather = new ForecastIo("YOUR FORECAST.IO API KEY HERE");
to 
var weather = new ForecastIo("YOUR FORECAST.IO OR DARKSKY.NET API KEY HERE");


Not sure if this fix is the best fix, but the author's example wasn't working, and when I went to 
http://developer.forecast.io 
as instructed in the printed book, I got redirected to: 
https://darksky.net/dev
It looks like DarkSky took over or is what became of http://forecast.io
When I searched the web for "forecastio", I found:
https://www.npmjs.com/package/forecast.io
I guess this is, or is equivalent to, what's used in the book, so I used it, as a wrapper for the darksky service, with sufficient success to make the app work.
See also "JavaScript" at https://darksky.net/dev/docs/libraries, not sure if
https://www.npmjs.com/package/forecast.io 
is listed there.  It seems like there are multiple "forecast.io" wrapper APIs for the DarkSky service.