### PR TITLE
Note darksky.net api key is ok to use for forecast.io api key

### DIFF
--- a/Chapter_05/temperature-by-zip-code/app.js
+++ b/Chapter_05/temperature-by-zip-code/app.js
@@ -4,7 +4,7 @@ var zipdb = require("zippity-do-dah");
 var ForecastIo = require("forecastio");
 
 var app = express();
-var weather = new ForecastIo("YOUR FORECAST.IO API KEY HERE");
+var weather = new ForecastIo("YOUR FORECAST.IO API KEY OR DARKSKY.NET API KEY HERE");
 
 app.use(express.static(path.resolve(__dirname, "public")));
 


### PR DESCRIPTION
No other problems found for ch5.  The problems I had with this example were partly due to uncertainty about whether darksky.net key is supported in place of the forecast.io key.  The original code seems to work fine for me now.  

When I tried to follow the book page 81 instructions saying get a key by going to 
https://developer.forecast.io
I was redirected to 
https://darksky.net/dev
so I became uncertain.  I probably could have gotten the code working straightforwardly, if I had the reassurance that the darksky key works in place of the forecast.io key.